### PR TITLE
Upgrade to Puppet 8 compatibility

### DIFF
--- a/manifests/node/install.pp
+++ b/manifests/node/install.pp
@@ -16,7 +16,7 @@
 #   An optional alias for the installed version. This is a string parameter. Defaults to undef.
 define nvm::node::install (
   String $user,
-  Pattern[/^\d+.\d+.\d+/] $version       = $title,
+  Pattern[/^\d+\.\d+\.\d+/] $version       = $title,
   Boolean                 $set_default   = false,
   Boolean                 $from_source   = false,
   Boolean                 $default       = false,

--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -24,8 +24,8 @@
 # @param cmd_exe_path
 #   The path to the command executable. This is a required parameter.
 define nvm::npm (
-  Pattern[/^\d+.\d+.\d+/]         $nodejs_version,
-  Pattern[/^[^<            >= ]/] $ensure             = 'present',
+  Pattern[/^\d+\.\d+\.\d+/]       $nodejs_version,
+  Pattern[/^[^<>=\s]+$/]          $ensure             = 'present',
   Array                           $install_options    = [],
   String                          $package            = $title,
   String                          $source             = 'registry',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
-# See README.md for usage information
+# @summary Default parameter values for the nvm module.
 class nvm::params {
   $manage_user         = false
   $manage_dependencies = true

--- a/metadata.json
+++ b/metadata.json
@@ -1,70 +1,48 @@
 {
-  "name": "artberri-nvm",
-  "version": "1.1.1",
-  "author": "artberri",
+  "name": "iwink-nvm",
+  "version": "2.0.0",
+  "author": "iwink",
   "summary": "Puppet Module to install Node.js with Node Version Manager (NVM)",
   "license": "Apache-2.0",
-  "source": "https://github.com/artberri/puppet-nvm",
-  "project_page": "https://github.com/artberri/puppet-nvm",
-  "issues_url": "https://github.com/artberri/puppet-nvm/issues",
+  "source": "https://github.com/iwink/puppet-nvm",
+  "project_page": "https://github.com/iwink/puppet-nvm",
+  "issues_url": "https://github.com/iwink/puppet-nvm/issues",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.0 <5.0.0"
+      "version_requirement": ">=6.6.0 <10.0.0"
     }
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7"
+        "11",
+        "12",
+        "13"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "10.04",
-        "12.04",
-        "14.04"
+        "20.04",
+        "22.04",
+        "24.04"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=2.7.20 <5.0.0"
+      "version_requirement": ">=6.0.0 <9.0.0"
     }
   ],
   "description": "A puppet module to install (multiple versions of) Node.js with NVM (Node Version Manager).",

--- a/metadata.json
+++ b/metadata.json
@@ -10,49 +10,55 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=6.6.0 <10.0.0"
+      "version_requirement": ">=5.2.0 <10.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "11",
-        "12",
-        "13"
-      ]
+      "operatingsystemrelease": ["10", "11", "12", "13"]
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "20.04",
-        "22.04",
-        "24.04"
-      ]
+      "operatingsystemrelease": ["18.04", "20.04", "22.04", "24.04"]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": ["7", "8", "9"]
     },
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7",
-        "8",
-        "9"
-      ]
+      "operatingsystemrelease": ["7", "8", "9"]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": ["8", "9"]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": ["8", "9"]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": ["7", "8", "9"]
+    },
+    {
+      "operatingsystem": "Amazon",
+      "operatingsystemrelease": ["2", "2023"]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": ["12", "15"]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=6.0.0 <9.0.0"
+      "version_requirement": ">=5.0.0 <9.0.0"
     }
   ],
   "description": "A puppet module to install (multiple versions of) Node.js with NVM (Node Version Manager).",
-  "tags": [
-    "nvm",
-    "nodejs",
-    "node.js",
-    "node",
-    "npm"
-  ],
+  "tags": ["nvm", "nodejs", "node.js", "node", "npm"],
   "pdk-version": "3.4.0",
   "template-url": "pdk-default#3.4.0",
   "template-ref": "tags/3.4.0-0-gd3cc13f"


### PR DESCRIPTION
- Bump puppet requirement to >=6.0.0 <9.0.0
- Bump stdlib dependency to >=6.6.0 <10.0.0
- Update module name/author/URLs to iwink fork
- Bump version to 2.0.0
- Update OS support to modern Debian/Ubuntu/CentOS
- Tighten regex patterns for version and ensure parameters
- Add @summary docstring to params.pp